### PR TITLE
IDE & Static

### DIFF
--- a/src/Belt/Belt.php
+++ b/src/Belt/Belt.php
@@ -26,6 +26,13 @@ class Belt {
     protected $instances = [];
 
     /**
+     * Instance of Belt for static calls
+     *
+     * @var Belt
+     */
+    protected static $instance = false;
+
+    /**
      * Load a module.
      *
      * @throws UnexpectedValueException
@@ -168,7 +175,11 @@ class Belt {
      */
     public static function __callStatic($method, array $arguments = array())
     {
-        return call_user_func_array([new static, $method], $arguments);
+        if(!self::$instance)
+        {
+            self::$instance = new static;
+        }
+        return call_user_func_array([self::$instance, $method], $arguments);
     }
 
 }

--- a/src/Belt/Functions.php
+++ b/src/Belt/Functions.php
@@ -33,7 +33,7 @@ class Functions {
      */
     public function cache(Closure $closure)
     {
-        $hash = spl_object_hash($closure);
+        $hash = spl_object_hash((object)$closure);
 
         if ( ! isset ($this->cached[$hash]))
         {
@@ -82,7 +82,7 @@ class Functions {
      */
     public function once(Closure $closure)
     {
-        $hash = spl_object_hash($closure);
+        $hash = spl_object_hash((object)$closure);
 
         if ( ! isset ($this->called[$hash]))
         {
@@ -101,7 +101,7 @@ class Functions {
      */
     public function after($number, Closure $closure)
     {
-        $hash = spl_object_hash($closure);
+        $hash = spl_object_hash((object)$closure);
 
         if (isset ($this->delayed[$hash]))
         {
@@ -120,7 +120,11 @@ class Functions {
             {
                 return $closure();
             }
+
+            return null;
         };
+
+        return null;
     }
 
 }


### PR DESCRIPTION
IDE will no longer display warnings(spl_object_hash takes object as argument).
Static method calls should work fine now(at least method after(), from Functions doesn't work as expected for static calls).
