### PR TITLE
Fixed without method not in strict mode

### DIFF
--- a/spec/Belt/ArraysSpec.php
+++ b/spec/Belt/ArraysSpec.php
@@ -93,11 +93,11 @@ class ArraysSpec extends ObjectBehavior {
 
     function it_removes_all_instances_from_the_array()
     {
-        $elements = ['foo', 'baz', 'bar', 'wow', 'doge'];
+        $elements = ['foo', 'baz', 'bar', 'wow', 'doge', 1];
 
-        $ignore = ['baz', 'wow'];
+        $ignore = ['baz', 'wow', '1'];
 
-        $this->without($elements, $ignore)->shouldBe(['foo', 'bar', 'doge']);
+        $this->without($elements, $ignore)->shouldBe(['foo', 'bar', 'doge', 1]);
     }
 
     function it_merges_two_arrays()
@@ -137,4 +137,3 @@ class ArraysSpec extends ObjectBehavior {
     }
 
 }
-

--- a/src/Belt/Arrays.php
+++ b/src/Belt/Arrays.php
@@ -149,7 +149,7 @@ class Arrays {
     {
         foreach ($elements as $key => $node)
         {
-            if (in_array($node, $ignore))
+            if (in_array($node, $ignore, true))
             {
                 unset ($elements[$key]);
             }
@@ -207,4 +207,3 @@ class Arrays {
     }
 
 }
-


### PR DESCRIPTION
Hey there,

The documentation says the `without` method uses `===` but it's not currently the case as in_array's third argument is set to `false` by default.

This pull request fixes this.
